### PR TITLE
feat: promisify and remove firefox interrupt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 node_modules
 package-lock.json
 lib

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "devcert-sanscache",
+  "name": "@magento/devcert",
   "version": "0.4.5",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
   "main": "index.js",
@@ -8,9 +8,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/guybedford/devcert.git"
+    "url": "git+https://github.com/magento-research/devcert.git"
   },
-  "author": "Dave Wasmer",
+  "author": "Magento Inc. and Dave Wasmer",
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^8.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@magento/devcert",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "Generate trusted local SSL/TLS certificates for local SSL development",
   "main": "index.js",
   "scripts": {

--- a/src/child_process-promisified.ts
+++ b/src/child_process-promisified.ts
@@ -1,0 +1,3 @@
+import cp = require('child_process');
+import util = require('util');
+export const exec: (cmd: string, opts?: any) => Promise<any> = util.promisify(cp.exec);

--- a/src/fs-promisified.ts
+++ b/src/fs-promisified.ts
@@ -1,0 +1,7 @@
+import util = require('util');
+import fs = require('fs');
+export const readFile = util.promisify(fs.readFile);
+export const writeFile = util.promisify(fs.writeFile);
+export const unlink = util.promisify(fs.unlink);
+export const access = util.promisify(fs.access);
+export const chmod = util.promisify(fs.chmod);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,27 @@
-import commandExists = require('command-exists');
+const { promisify } = require('util');
+import _cmdExists = require('command-exists');
+const commandExists = promisify(_cmdExists);
 import installAuthority from './install-authority';
 import { generateOpensslConf, generateRootCertificate, generateSignedCertificate, tmpClear } from './openssl';
-import fs = require('fs');
+import fs = require('./fs-promisified');
 
-export default async function generateDevCert (commonName: string) {
-  if (!commandExists.sync('openssl'))
+async function generateDevCert (commonName: string) {
+  if (!(await commandExists('openssl')))
     throw new Error('Unable to find openssl - make sure it is installed and available in your PATH');
   if (!commonName.match(/^(.|\.){1,64}$/))
     throw new Error(`Invalid Common Name ${commonName}.`);
   try {
-    const opensslConfPath = generateOpensslConf(commonName);
+    const opensslConfPath = await generateOpensslConf(commonName);
     const { rootKeyPath, rootCertPath } = await generateRootCertificate(commonName, opensslConfPath);
     await installAuthority(commonName, rootCertPath);
-    const { keyPath, certPath, caPath } = generateSignedCertificate(commonName, opensslConfPath, rootKeyPath, rootCertPath);
-    const key = fs.readFileSync(keyPath).toString();
-    const cert = fs.readFileSync(certPath).toString();
-    const ca = fs.readFileSync(caPath).toString();
+    const { keyPath, certPath, caPath } = await generateSignedCertificate(commonName, opensslConfPath, rootKeyPath, rootCertPath);
+    const [key, cert, ca] = await Promise.all([keyPath, certPath, caPath].map(filepath => fs.readFile(filepath, 'utf8')));
     return { key, cert, ca };
   }
   finally {
     // clear all tmp files (including root cert!)
-    tmpClear();
+    await tmpClear();
   }
 }
+
+export default generateDevCert;


### PR DESCRIPTION
Updates for use by [pwa-buildpack](https://github.com/magento-research/pwa-buildpack).

Issues:
 - Original Firefox strategy involves interrupting startup to open Firefox, adding to initial config burden
 - Usage of sync I/O is against PWA Studio best practice
 - In one common use case, pwa-buildpack needs to create two SSL certificates, which requires two passwords, since @guybedford's `sanscache` version deletes the CA key after every new cert

Changes: 
 - No more Firefox interrupt fallback window (TODO: make configurable)
 - Async methods wherever possible
 - Compromise between the security risks of the [original implementation by @davewasmer](https://github.com/davewasmer/devcert) and the UX drawback of the [fork by @guybedford](https://github.com/guybedford/devcert):
     - Deletes the private key file immediately after creating certificate authority
     - Keeps private key string in memory to allow current process to create more than one cert